### PR TITLE
Kill processes spawned by child process. 

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,7 +89,7 @@ class Dotnet {
   start(task, done){
     // only do first time
     if(!this.child){
-      process.on('exit', this.kill);
+      process.on('exit', () => this.kill());
     }
     
     if (this.child) {

--- a/index.js
+++ b/index.js
@@ -94,7 +94,7 @@ class Dotnet {
     
     if (this.child) {
       this.log(logLevels.INFO, 'Restarting');
-      this.child.kill();
+      this.kill();
     }
     
     if(this.starting) {
@@ -105,7 +105,8 @@ class Dotnet {
       
     this.starting = true;
     this.child = proc.spawn('dotnet', [task], {
-      cwd: this.options.cwd
+      cwd: this.options.cwd,
+      detached: true
     });
     
     this.child.stdout.on('data', (data) => {
@@ -142,7 +143,7 @@ class Dotnet {
     if (this.child) {
       this.started = false;
       this.starting = false;
-      this.child.kill();
+      process.kill(-this.child.pid);
     }
   }
   


### PR DESCRIPTION
When attempting to restart the dotnet process, other child processes created by dotnet are still running, which results in dotnet crashing. By using the pid range hack we can kill all processes within the pid range. See http://azimi.me/2014/12/31/kill-child_process-node-js.html.
